### PR TITLE
feat: use DOMLoaded event instead of data_ready

### DIFF
--- a/src/RemotionLottie.tsx
+++ b/src/RemotionLottie.tsx
@@ -53,17 +53,10 @@ const RemotionLottie = ({
 			continueRender(handle);
 		};
 
-		// Workaround for Lottie behaviour: the `data_ready` event
-		// is not fired when the animation is loaded from a file
-		if (animationData) {
-			onComplete();
-			return;
-		}
-
-		animation.addEventListener('data_ready', onComplete);
+		animation.addEventListener('DOMLoaded', onComplete);
 
 		return () => {
-			animation.removeEventListener('data_ready', onComplete);
+			animation.removeEventListener('DOMLoaded', onComplete);
 			animation.destroy();
 		};
 	}, [animationData, handle, path, speed]);


### PR DESCRIPTION
`DOMLoaded` seems to be the most reliable event since it works with both `animationData` and `path`.